### PR TITLE
Fix fd leak when timerfd is disabled on Linux.

### DIFF
--- a/mpsrc/wavy_kernel_epoll.h
+++ b/mpsrc/wavy_kernel_epoll.h
@@ -176,11 +176,14 @@ public:
 #else // DISABLE_TIMERFD
 	class timer {
 	public:
-		timer() : fd(-1) { }
+		timer() : fd(-1), fd_writer(-1) { }
 		~timer() {
 			if(fd >= 0) {
 				timer_delete(timer_id);
 				::close(fd);
+			}
+			if(fd_writer >= 0) {
+				::close(fd_writer);
 			}
 		}
 
@@ -188,6 +191,7 @@ public:
 
 	private:
 		int fd;
+		int fd_writer;
 		timer_t timer_id;
 		friend class kernel;
 		timer(const timer&);
@@ -259,6 +263,7 @@ public:
 		}
 
 		tm->fd = pipefd[0];
+		tm->fd_writer = pipefd[1];
 		tm->timer_id = timer_id;
 
 		return pipefd[0];

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,6 +9,7 @@ check_PROGRAMS = \
 		handler \
 		signal \
 		timer \
+		many_timer \
 		sync
 
 TESTS = $(check_PROGRAMS)
@@ -20,6 +21,8 @@ handler_SOURCES = handler.cc
 signal_SOURCES = signal.cc
 
 timer_SOURCES = timer.cc
+
+many_timer_SOURCES = many_timer.cc
 
 sync_SOURCES = sync.cc
 

--- a/test/many_timer.cc
+++ b/test/many_timer.cc
@@ -1,0 +1,38 @@
+// Copyright (C) 2013 Preferred Infrastructure and Nippon Telegraph and Telephone Corporation.
+
+#include <jubatus/mp/wavy.h>
+#include <jubatus/mp/functional.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <cstdlib>
+#include <iostream>
+
+using namespace mp::placeholders;
+
+bool timer_handler(int* count, mp::wavy::loop* lo)
+{
+	try {
+		std::cout << "*" << std::flush;
+		if(--(*count) < 0) {
+			lo->end();
+		}
+		else {
+		    lo->add_timer(0.001, 0, mp::bind(&timer_handler, count, lo));
+		}
+		return false;
+	}
+	catch (std::exception& e) {
+		std::cerr <<  e.what() << std::endl;
+		std::exit(1);
+	}
+}
+
+int main(void)
+{
+	mp::wavy::loop lo;
+	int count = 2000;
+	lo.add_timer(0.01, 0, mp::bind(
+				&timer_handler, &count, &lo));
+	lo.run(4);
+	std::cout << std::endl;
+}


### PR DESCRIPTION
Hello.

I tried to use jubatus in CentOS 5.8 but jubatus did not run normally.
When I investigated, there was the file-descriptor leak in timer of mpio with --disable-timerfd configure option on Linux.

With --disable-timerfd on Linux, timer of mpio uses a pair of pipes for communication between timer handler and epoll.  And timer handler side of the pipes is not closed.

This request fixes this leak and adds test code(test/many_timer.cc).
