### PR TITLE
Fix memory leak when client is disconnected before sending back results (fixes #12)

### DIFF
--- a/mpsrc/wavy_loop.cc
+++ b/mpsrc/wavy_loop.cc
@@ -157,6 +157,7 @@ shared_ptr<basic_handler> loop_impl::add_handler_impl(shared_ptr<basic_handler> 
 
 void loop_impl::remove_handler(int fd)
 {
+	m_out->clear_xfer(fd);
 	reset_handler(fd);
 	m_kernel.remove_fd(fd, EVKERNEL_READ);
 }

--- a/mpsrc/wavy_out.cc
+++ b/mpsrc/wavy_out.cc
@@ -518,6 +518,14 @@ void out::write(int fd, const void* buf, size_t size)
 	}
 }
 
+void out::clear_xfer(int fd)
+{
+	xfer_impl& ctx(ANON_fdctx[fd]);
+	pthread_scoped_lock lk(ctx.mutex());
+
+	ctx.clear();
+}
+
 
 #define ANON_out static_cast<loop_impl*>(m_impl)->m_out
 

--- a/mpsrc/wavy_out.h
+++ b/mpsrc/wavy_out.h
@@ -43,6 +43,8 @@ public:
 	inline void commit(int fd, xfer* xf);
 	inline void write(int fd, const void* buf, size_t size);
 
+	inline void clear_xfer(int fd);
+
 public:
 	kernel& get_kernel()
 	{


### PR DESCRIPTION
This fixes https://github.com/jubatus/jubatus-mpio/issues/12.
