### PR TITLE
Enable to use a build directory different to source directory

### DIFF
--- a/mpsrc/Makefile.am
+++ b/mpsrc/Makefile.am
@@ -3,7 +3,7 @@
 lib_LTLIBRARIES = libjubatus_mpio.la
 
 libjubatus_mpio_la_LDFLAGS = -version-info 4:3:4
-libjubatus_mpio_la_CPPFLAGS = -I..
+libjubatus_mpio_la_CPPFLAGS = -I$(top_srcdir)
 
 libjubatus_mpio_la_SOURCES = \
 		wavy_connect.cc \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,8 +1,8 @@
 # Copyright (C) 2013 Preferred Infrastructure and Nippon Telegraph and Telephone Corporation.
 
-AM_CPPFLAGS   = -I..
-AM_C_CPPFLAGS = -I..
-AM_LDFLAGS = ../mpsrc/libjubatus_mpio.la
+AM_CPPFLAGS   = -isystem $(top_srcdir)
+AM_C_CPPFLAGS = -isystem $(top_srcdir)
+AM_LDFLAGS = $(top_builddir)/mpsrc/libjubatus_mpio.la
 
 check_PROGRAMS = \
 		listen_connect \


### PR DESCRIPTION
I got error when I tried to build in another directory s.t.

```console
liquid@foo ~/work/source/jubatus-mpio
 % mkdir build
liquid@foo ~/work/source/jubatus-mpio
 % cd build/
liquid@foo ~/work/source/jubatus-mpio/build
 % ../configure
liquid@foo ~/work/source/jubatus-mpio/build
 % make
make  all-recursive
make[1]: ディレクトリ `/home/katsuaki_ikegami/work/source/jubatus-mpio/build' に入ります
Making all in jubatus/mp
make[2]: ディレクトリ `/home/katsuaki_ikegami/work/source/jubatus-mpio/build/jubatus/mp' に入ります
make[2]: `all' に対して行うべき事はありません.
make[2]: ディレクトリ `/home/katsuaki_ikegami/work/source/jubatus-mpio/build/jubatus/mp' から出ます
Making all in mpsrc
make[2]: ディレクトリ `/home/katsuaki_ikegami/work/source/jubatus-mpio/build/mpsrc' に入ります
/bin/sh ../libtool  --tag=CXX   --mode=compile g++ -DHAVE_CONFIG_H -I. -I../../mpsrc -I..  -I..  -pthread -g -O2 -g -MT libjubatus_mpio_la-wavy_connect.lo -MD -MP -MF .deps/libjubatus_mpio_la-wavy_connect.Tpo -c -o libjubatus_mpio_la-wavy_connect.lo `test -f 'wavy_connect.cc' || echo '../../mpsrc/'`wa
vy_connect.cc
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I../../mpsrc -I.. -I.. -pthread -g -O2 -g -MT libjubatus_mpio_la-wavy_connect.lo -MD -MP -MF .deps/libjubatus_mpio_la-wavy_connect.Tpo -c ../../mpsrc/wavy_connect.cc  -fPIC -DPIC -o .libs/libjubatus_mpio_la-wavy_connect.o
../../mpsrc/wavy_connect.cc:18 から include されたファイル中:
../../mpsrc/wavy_loop.h:22:29: error: jubatus/mp/wavy.h: そのようなファイルやディレクトリはありません
../../mpsrc/wavy_loop.h:23:32: error: jubatus/mp/pthread.h: そのようなファイルやディレクトリはありません
../../mpsrc/wavy_kernel.h:50 から include されたファイル中,
                 ../../mpsrc/wavy_loop.h:24 から,
                 ../../mpsrc/wavy_connect.cc:18 から:
../../mpsrc/./wavy_kernel_epoll.h:22:34: error: jubatus/mp/exception.h: そのようなファイルやディレクトリはありません
(略)
```

Maybe we should use `top_srcdir` or `top_builddir` to specify relative directory path instead of `..`.
Refer: http://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Preset-Output-Variables.html